### PR TITLE
Add errors to matrix default template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## 1.3.0 - 
 
 ### Added
-- Added an `:hover` selector to `matrix.hbs` that shows test errors.
+- Add an `:hover` selector to `matrix.hbs` that shows test errors.
+- Add a new template option error for displaying test errors.
 
 ### Fixed
-- Adds a NaN check to the percent method.
+- Add a NaN check to the percent method.
 
 ## 1.2.1 - 2022-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # @digitalbazaar/mocha-w3c-interop-reporter ChangeLog
 
-## 1.2.2 - 
+## 1.3.0 - 
+
+### Added
+- Added an `:hover` selector to `matrix.hbs` that shows test errors.
 
 ### Fixed
 - Adds a NaN check to the percent method.

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,8 @@ export const getConfig = ({reporterOptions = {}} = {}) => {
         join(templatesPath, 'abstract.hbs'),
       body: reporterOptions.body ||
         join(templatesPath, 'body.hbs'),
+      error: reporterOptions.error ||
+        join(templatesPath, 'error.hbs'),
       head: reporterOptions.head ||
         join(templatesPath, 'head.hbs'),
       metrics: reporterOptions.metrics ||

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -27,6 +27,7 @@ export async function makeReport({suite, stats, config}) {
   // from disk into handlebars
   await getPartial({filePath: templates.head, name: 'head.hbs'});
   await getPartial({filePath: templates.body, name: 'body.hbs'});
+  await getPartial({filePath: templates.error, name: 'error.hbs'});
   await getPartial({filePath: templates.metrics, name: 'metrics.hbs'});
   await getPartial({filePath: templates.matrix, name: 'matrix.hbs'});
   await getPartial({

--- a/lib/handlebars.js
+++ b/lib/handlebars.js
@@ -13,6 +13,8 @@ const registerHelpers = ({config}) => {
     state => statusMarks[state] || statusMarks.pending);
 
   Handlebars.registerHelper('formatJSON', data => formatJSON({data}));
+  Handlebars.registerHelper('formatError', ({name, message, stack} = {}) =>
+    formatJSON({data: {name, message, stack}}));
 
   Handlebars.registerHelper('today', () => {
     // use the lang from respecConfig or set it to the

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -75,6 +75,7 @@ export function makeRows({tests, implemented, notImplemented}) {
     return rows;
   }, []);
   return _rows.map(({id, cells}) => {
+    // fill if not implemented columns with not implemented
     for(const colName of notImplemented) {
       const columnIndex = columnIds.indexOf(colName);
       cells[columnIndex] = {

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -8,7 +8,7 @@
      z-index: 1;
      width: 50rem;
      right: calc(0% + 15rem);
-     background: rgba(255, 255, 255, 0.0);
+     background: rgba(0, 0, 0, 0.0);
    }
    .no-space-around {
      margin: 0;
@@ -26,9 +26,9 @@
      margin-left: 1rem;
    }
   </style>
+  {{#if error}}
   <span class="err hide no-space-around">
-    {{#if error}}
-      <pre>{{{formatJSON error}}}</pre>
-    {{/if}}
+    <pre>{{{formatError error}}}</pre>
   </span>
+  {{/if}}
 </div>

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -7,7 +7,7 @@
      position: relative;
      z-index: 1;
      width: 50rem;
-     left: -150px;
+     right: calc(0% + 15rem);
      background: rgba(255, 255, 255, 0.0);
    }
    .no-space-around {
@@ -20,6 +20,7 @@
      word-break: break-all;
      margin: 0;
      padding: 0;
+     background: white;
    }
    code > span.hljs-attr {
      margin-left: 1rem;

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,5 +1,7 @@
-<span class="err hide no-space-around">
-   {{#if error}}
-     <pre>{{{formatJSON error}}}</pre>
-   {{/if}}
- </span>
+<div class="relative-pos">
+  <span class="err hide no-space-around">
+    {{#if error}}
+      <pre>{{{formatJSON error}}}</pre>
+    {{/if}}
+  </span>
+</div>

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -5,7 +5,7 @@
    }
    .err {
      position: relative;
-     z-index: 2;
+     z-index: 1;
      width: 50rem;
      left: -150px;
      background: rgba(255, 255, 255, 0.0);

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,4 +1,30 @@
 <div class="relative-pos">
+  <style>
+   .hide {
+     display: none;
+   }
+   .err {
+     position: relative;
+     z-index: 2;
+     width: 50rem;
+     left: -150px;
+     background: rgba(255, 255, 255, 0.0);
+   }
+   .no-space-around {
+     margin: 0;
+     padding: 0;
+   }
+   pre {
+     width: 75%;
+     white-space: pre-line;
+     word-break: break-all;
+     margin: 0;
+     padding: 0;
+   }
+   code > span.hljs-attr {
+     margin-left: 1rem;
+   }
+  </style>
   <span class="err hide no-space-around">
     {{#if error}}
       <pre>{{{formatJSON error}}}</pre>

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,0 +1,5 @@
+<span class="err hide no-space-around">
+   {{#if error}}
+     <pre>{{{formatJSON error}}}</pre>
+   {{/if}}
+ </span>

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -36,6 +36,10 @@
    .hide {
      display: none;
    }
+   .no-space-around {
+     margin: 0;
+     padding: 0;
+   }
    .err {
      position: absolute;
      background-color: white;
@@ -47,6 +51,13 @@
    .highlight-on-hover:hover + .err {
      display: block;
      z-index: 1;
+   }
+   pre {
+     width: 75%;
+     white-space: pre-line;
+     word-break: break-all;
+     margin: 0;
+     padding: 0;
    }
   </style>
   <div class="row justify-center">
@@ -74,9 +85,9 @@
           <td class="{{state}} {{getOptional optional}} highlight-on-hover">
             <div class= "highlight-on-hover">{{getStatusMark state}}</div>
             {{#if err}}
-              <div class="err hide">
-                <pre style="white-space: break-spaces; word-break: break-all;">{{{formatJSON err}}}</pre>
-              </div>
+              <span class="err hide no-space-around">
+                <pre>{{{formatJSON err}}}</pre>
+              </span>
             {{/if}}
           </td>
         {{/each}}

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -32,6 +32,7 @@
    }
    .highlight-on-hover:hover {
      background-color: yellow;
+     cursor: default;
    }
    .highlight-on-hover:hover + .relative-pos > .err {
      display: block;

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -33,6 +33,16 @@
    pre, code.hljs{
      overflow: auto;
    }
+   .highlight-on-hover:hover {
+     background-color: yellow;
+   }
+   .highlight-on-hover:hover + .err {
+     display: block;
+     z-index: 1;
+   }
+   pre, code.hljs{
+     overflow: auto;
+   }
    .hide {
      display: none;
    }
@@ -44,13 +54,6 @@
      position: absolute;
      background-color: white;
      width: 50%;
-   }
-   .highlight-on-hover:hover {
-     background-color: yellow;
-   }
-   .highlight-on-hover:hover + .err {
-     display: block;
-     z-index: 1;
    }
    pre {
      width: 75%;
@@ -84,11 +87,7 @@
         {{#each cells}}
           <td class="{{state}} {{getOptional optional}} highlight-on-hover">
             <div class= "highlight-on-hover">{{getStatusMark state}}</div>
-            {{#if err}}
-              <span class="err hide no-space-around">
-                <pre>{{{formatJSON err}}}</pre>
-              </span>
-            {{/if}}
+            {{> error.hbs error=err}}
           </td>
         {{/each}}
       </tr>

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -49,8 +49,11 @@
      background-color: white;
      width: 50%;
    }
-   pre, code.hljs{
+   pre, code.hljs {
      overflow: auto;
+   }
+   code > span.hljs-attr {
+     margin-left: 1rem;
    }
    pre {
      width: 75%;

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -35,40 +35,17 @@
    }
    .highlight-on-hover:hover + .relative-pos > .err {
      display: block;
-     z-index: 1;
-   }
-   .hide {
-     display: none;
-   }
-   .no-space-around {
-     margin: 0;
-     padding: 0;
-   }
-   .err {
-     position: absolute;
-     width: 50rem;
-     left: -150px;
-     background: rgba(255, 255, 255, 0.0);
    }
    pre, code.hljs {
      overflow: auto;
    }
-   code > span.hljs-attr {
-     margin-left: 1rem;
-   }
-   pre {
-     width: 75%;
-     white-space: pre-line;
-     word-break: break-all;
-     margin: 0;
-     padding: 0;
+   .relative-pos {
+     position: relative;
+     width: 0.5rem;
+     z-index: 1;
    }
    .relative-pos:hover > .err {
      display: block;
-     z-index: 1;
-   }
-   .relative-pos {
-     position: relative;
    }
   </style>
   <div class="row justify-center">

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -33,6 +33,21 @@
    pre, code.hljs{
      overflow: auto;
    }
+   .hide {
+     display: none;
+   }
+   .err {
+     position: absolute;
+     background-color: white;
+     width: 50%;
+   }
+   .highlight-on-hover:hover {
+     background-color: yellow;
+   }
+   .highlight-on-hover:hover + .err {
+     display: block;
+     z-index: 1;
+   }
   </style>
   <div class="row justify-center">
     <table class="simple">
@@ -56,7 +71,14 @@
         <td class="subtest">{{id}}</td>
         <!--These contain if the test passed, failed, or was skipped-->
         {{#each cells}}
-          <td class="{{state}} {{getOptional optional}}">{{getStatusMark state}}</td>
+          <td class="{{state}} {{getOptional optional}} highlight-on-hover">
+            <div class= "highlight-on-hover">{{getStatusMark state}}</div>
+            {{#if err}}
+              <div class="err hide">
+                <pre style="white-space: break-spaces; word-break: break-all;">{{{formatJSON err}}}</pre>
+              </div>
+            {{/if}}
+          </td>
         {{/each}}
       </tr>
     {{/each}}

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -44,7 +44,7 @@
      position: relative;
      width: 0.5rem;
      height: 0.5rem;
-     z-index: 0;
+     z-index: 1;
    }
    .relative-pos:hover > .err {
      display: block;

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -33,7 +33,7 @@
    .highlight-on-hover:hover {
      background-color: yellow;
    }
-   .highlight-on-hover:hover + .err {
+   .highlight-on-hover:hover + .relative-pos > .err {
      display: block;
      z-index: 1;
    }
@@ -46,8 +46,9 @@
    }
    .err {
      position: absolute;
-     background-color: white;
-     width: 50%;
+     width: 50rem;
+     left: -150px;
+     background: rgba(255, 255, 255, 0.0);
    }
    pre, code.hljs {
      overflow: auto;
@@ -61,6 +62,13 @@
      word-break: break-all;
      margin: 0;
      padding: 0;
+   }
+   .relative-pos:hover > .err {
+     display: block;
+     z-index: 1;
+   }
+   .relative-pos {
+     position: relative;
    }
   </style>
   <div class="row justify-center">

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -30,18 +30,12 @@
    .small-font {
      font-size: 0.75rem;
    }
-   pre, code.hljs{
-     overflow: auto;
-   }
    .highlight-on-hover:hover {
      background-color: yellow;
    }
    .highlight-on-hover:hover + .err {
      display: block;
      z-index: 1;
-   }
-   pre, code.hljs{
-     overflow: auto;
    }
    .hide {
      display: none;
@@ -54,6 +48,9 @@
      position: absolute;
      background-color: white;
      width: 50%;
+   }
+   pre, code.hljs{
+     overflow: auto;
    }
    pre {
      width: 75%;

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -42,7 +42,7 @@
    .relative-pos {
      position: relative;
      width: 0.5rem;
-     z-index: 1;
+     z-index: 0;
    }
    .relative-pos:hover > .err {
      display: block;

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -42,6 +42,7 @@
    .relative-pos {
      position: relative;
      width: 0.5rem;
+     height: 0.5rem;
      z-index: 0;
    }
    .relative-pos:hover > .err {


### PR DESCRIPTION
Adds an error display that shows why a test failed on mouse over.
Fixes possibly the most annoying part of the reports: not knowing why a test failed when looking at the report html.
![20220705_15h20m29s_grim](https://user-images.githubusercontent.com/278280/177400132-a5acd704-7f22-4485-9a32-efc36d230649.png)
