### PR TITLE
Use is infinite check

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -168,8 +168,12 @@ export function formatTest(test, parentSuite = '') {
 */
 function percent(observations, total) {
   const p = observations / total * 100;
-  // in case of a zero divide etc return 0
-  if(Number.isNaN(p)) {
+  // 0/0 is NaN
+  // 3/0 is Infinity
+  // This covers some peculiarities of mocha's test stats
+  // such as when failures is greater than 0 and tests run is 0
+  // this occurs when before steps fail
+  if(!Number.isFinite(p)) {
     return 0;
   }
   return p;
@@ -205,6 +209,7 @@ export function formatStats({passes, tests, failures, pending}) {
   return [
     `Tests passed ${passes}/${testsRun} ${passPercent}%`,
     `Tests failed ${failures}/${testsRun} ${failPercent}%`,
+    `Failures ${failures}`,
     `Tests skipped ${pending}`,
     `Total tests ${tests}`
   ];

--- a/test/mocha/10-handlers.js
+++ b/test/mocha/10-handlers.js
@@ -15,6 +15,7 @@ describe('Handlers.js', function() {
     const expectedResult = [
       `Tests passed ${passes}/${tests} 100%`,
       `Tests failed ${failures}/${tests} 0%`,
+      `Failures ${failures}`,
       `Tests skipped ${pending}`,
       `Total tests ${tests}`
     ];
@@ -37,6 +38,7 @@ describe('Handlers.js', function() {
     const expectedResult = [
       `Tests passed ${passes}/${tests} 50%`,
       `Tests failed ${failures}/${tests} 50%`,
+      `Failures ${failures}`,
       `Tests skipped ${pending}`,
       `Total tests ${tests}`
     ];
@@ -60,6 +62,7 @@ describe('Handlers.js', function() {
     const expectedResult = [
       `Tests passed ${passes}/${tests} 0%`,
       `Tests failed ${failures}/${tests} 100%`,
+      `Failures ${failures}`,
       `Tests skipped ${pending}`,
       `Total tests ${tests}`
     ];
@@ -82,6 +85,7 @@ describe('Handlers.js', function() {
     const expectedResult = [
       `Tests passed ${passes}/${tests} 34%`,
       `Tests failed ${failures}/${tests} 66%`,
+      `Failures ${failures}`,
       `Tests skipped ${pending}`,
       `Total tests ${tests}`
     ];
@@ -104,6 +108,7 @@ describe('Handlers.js', function() {
     const expectedResult = [
       `Tests passed ${passes}/${tests} 99%`,
       `Tests failed ${failures}/${tests} 1%`,
+      `Failures ${failures}`,
       `Tests skipped ${pending}`,
       `Total tests ${tests}`
     ];


### PR DESCRIPTION
Ok so javascript considers `3/0 === Infinity` so this leads to situations where if the before statement fails no tests are run so there are more failures than tests that run which results in `3/0` in some cases.