### PR TITLE
Mark missing tests pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/mocha-w3c-interop-reporter ChangeLog
 
+## 1.4.0 -
+
+### Added
+- If an implementation fails to run a test mark the test pending.
+
 ## 1.3.0 - 2022-11-09
 
 ### Added

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -86,7 +86,10 @@ export function makeRows({tests, implemented, notImplemented}) {
             rowId: id,
             colId: colName
           },
-          state: 'pending'
+          state: 'pending',
+          err: {
+            message: 'Test failed to run.'
+          }
         };
       }
     }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -75,6 +75,21 @@ export function makeRows({tests, implemented, notImplemented}) {
     return rows;
   }, []);
   return _rows.map(({id, cells}) => {
+    // check that all implementations have results
+    for(const colName of implemented) {
+      const result = cells.find(test => test?.cell?.columnId === colName);
+      // if an implementation doesn't have a result add a pending
+      if(!result) {
+        const columnIndex = columnIds.indexOf(colName);
+        cells[columnIndex] = {
+          cell: {
+            rowId: id,
+            colId: colName
+          },
+          state: 'pending'
+        };
+      }
+    }
     // fill if not implemented columns with not implemented
     for(const colName of notImplemented) {
       const columnIndex = columnIds.indexOf(colName);

--- a/templates/head.hbs
+++ b/templates/head.hbs
@@ -14,17 +14,18 @@
 .passed {
   font-weight: bold;
   background-color: lightgreen;
-  text-align: center;
 }
 .failed {
   font-weight: bold;
   background-color: pink;
-  text-align: center;
+}
+.pending {
+  font-weight: bold;
+  background-color: #cdeaed;
 }
 .unimplemented, .notImplemented {
   font-weight: bold;
   background-color: lightyellow;
-  text-align: center;
 }
 .flex-center {
   display: flex;

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -72,7 +72,7 @@
         <td class="subtest">{{id}}</td>
         <!--These contain if the test passed, failed, or was skipped-->
         {{#each cells}}
-          <td class="{{state}} {{getOptional optional}} highlight-on-hover">
+          <td class="{{state}} {{getOptional optional}} highlight-on-hover text-center">
             <div class= "highlight-on-hover">{{getStatusMark state}}</div>
             {{> error.hbs error=err}}
           </td>


### PR DESCRIPTION
Fixes a bug where if an implementation opts into a test suite (they show up in implemented) if the before statement in a suite fails and the tests are not run for an implementer then this results in a blank cell in the report which is filled in by the next implementor's test result which causes false positives and negatives in the report.


![20230721_14h46m16s_grim](https://github.com/digitalbazaar/mocha-w3c-interop-reporter/assets/278280/93059ef7-3957-4427-b08c-6ab09b45eb45)
