### PR TITLE
Fix css issues with sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/mocha-w3c-interop-reporter ChangeLog
 
+### 1.4.1 -
+
+### Fixed
+- Removed flex justify-center from conformance table to ensure normal spec layout.
+
 ## 1.4.0 -
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # @digitalbazaar/mocha-w3c-interop-reporter ChangeLog
 
-### 1.4.1 -
-
-### Fixed
-- Removed flex justify-center from conformance table to ensure normal spec layout.
-
 ## 1.4.0 -
 
 ### Added
 - If an implementation fails to run a test mark the test pending.
+
+### Fixed
+- Removed flex justify-center from conformance table to ensure normal spec layout.
 
 ## 1.3.0 - 2022-11-09
 

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -24,9 +24,6 @@
      justify-content: space-between;
      align-items: center;
    }
-   .row.justify-center {
-     justify-content: center;
-   }
    .small-font {
      font-size: 0.75rem;
    }
@@ -50,7 +47,7 @@
      display: block;
    }
   </style>
-  <div class="row justify-center">
+  <div class="row">
     <table class="simple">
       <thead>
         <th width="20%">


### PR DESCRIPTION
Addresses: https://github.com/digitalbazaar/mocha-w3c-interop-reporter/issues/25

Issue: conformance results were not displaying correctly when the sidebar was displaying
Fix: It turns out respec has issues with flex's `justify-center` so removing it recenters the results to a normal display.


![20230721_16h00m13s_grim](https://github.com/digitalbazaar/mocha-w3c-interop-reporter/assets/278280/9ce22150-3267-4a58-91a6-ad31dd5dfd9e)
![20230721_16h00m05s_grim](https://github.com/digitalbazaar/mocha-w3c-interop-reporter/assets/278280/a25e2d89-773f-4239-b286-7acd47a543b9)
