### PR TITLE
Allow linking test titles to specs.

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -67,14 +67,14 @@ export function makeRows({tests, implemented, notImplemented}) {
     let row = rows.find(f => f.id === rowId);
     // if there is no row add one
     if(!row) {
-      row = {id: rowId, cells: []};
+      row = {id: rowId, link: current.link, cells: []};
       rows.push(row);
     }
     // ensures a cell lines up with its row when rendered
     row.cells[columnIndex] = current;
     return rows;
   }, []);
-  return _rows.map(({id, cells}) => {
+  return _rows.map(({id, link, cells}) => {
     // check that all implementations have results
     for(const colName of implemented) {
       const result = cells.find(test => test?.cell?.columnId === colName);
@@ -104,7 +104,7 @@ export function makeRows({tests, implemented, notImplemented}) {
         state: 'notImplemented'
       };
     }
-    return {id, cells};
+    return {id, link, cells};
   });
 }
 

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -66,7 +66,13 @@
     {{#each matrix.rows}}
       <tr>
         <!--This is the name of the test-->
-        <td class="subtest">{{id}}</td>
+        <td class="subtest">
+          {{#if link}}
+            <a href="{{link}}">{{id}}</a>
+          {{else}}
+            {{id}}
+          {{/if}}
+        </td>
         <!--These contain if the test passed, failed, or was skipped-->
         {{#each cells}}
           <td class="{{state}} {{getOptional optional}} highlight-on-hover text-center">

--- a/test/multiple-matrix.json
+++ b/test/multiple-matrix.json
@@ -28,6 +28,7 @@
               "_testId": "urn:uuid:7d556c3e-3a4a-48da-bb11-a357c4ddb7f9",
               "_events": {},
               "_eventsCount": 1,
+              "link": "https://example.com/",
               "cell": {
                 "columnId": "Danube Tech",
                 "rowId": "MUST successfully issue a credential."
@@ -534,6 +535,7 @@
               "_testId": "urn:uuid:ac8ba57f-1e9a-4a6d-87a1-37b7e6731428",
               "_events": {},
               "_eventsCount": 1,
+              "link": "https://example.com/",
               "cell": {
                 "columnId": "Digital Bazaar",
                 "rowId": "MUST successfully issue a credential."
@@ -1140,6 +1142,7 @@
               "_testId": "urn:uuid:59b50b61-bece-4e8b-a8ed-5f0c5e1f9a02",
               "_events": {},
               "_eventsCount": 1,
+              "link": "https://example.com/",
               "cell": {
                 "columnId": "SecureKey",
                 "rowId": "MUST successfully issue a credential."
@@ -1647,6 +1650,7 @@
           "_testId": "urn:uuid:7d556c3e-3a4a-48da-bb11-a357c4ddb7f9",
           "_events": {},
           "_eventsCount": 1,
+          "link": "https://example.com/",
           "cell": {
             "columnId": "Danube Tech",
             "rowId": "MUST successfully issue a credential."
@@ -2131,6 +2135,7 @@
           "_testId": "urn:uuid:ac8ba57f-1e9a-4a6d-87a1-37b7e6731428",
           "_events": {},
           "_eventsCount": 1,
+          "link": "https://example.com/",
           "cell": {
             "columnId": "Digital Bazaar",
             "rowId": "MUST successfully issue a credential."
@@ -2715,6 +2720,7 @@
           "_testId": "urn:uuid:59b50b61-bece-4e8b-a8ed-5f0c5e1f9a02",
           "_events": {},
           "_eventsCount": 1,
+          "link": "https://example.com/",
           "cell": {
             "columnId": "SecureKey",
             "rowId": "MUST successfully issue a credential."


### PR DESCRIPTION
Rather than just having this at the comment level, we can move these into the test data itself.

The links to add would need to be added to the test data in a similar way as `test.cell` stuff is added here:
https://github.com/w3c/vc-data-model-2.0-test-suite/blob/main/tests/10-vcdm2.js#L40-L43

Not sure that's ideal...but it does work.

I can provide readme updates, if y'all think this approach is worth doing.

The easy way to add the data to a test is just...
```js
it('test', async function() {
  this.test.link = 'https://example.com/';
});
```

It's a little distracting...but works.