### PR TITLE
Improve error messages.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Copyright 2024 Digital Bazaar, Inc.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/templates/body.hbs
+++ b/templates/body.hbs
@@ -25,6 +25,51 @@
   code > span.hljs-attr {
     margin-left: 1rem;
   }
+  .no-wrap {
+    white-space: nowrap;
+  }
+  td.optional {
+    background-color: #b9b7b7;
+  }
+  .text-right {
+    text-align: right;
+  }
+  .text-left {
+    text-align: left;
+  }
+  .text-center, th.text-center {
+    text-align: center;
+  }
+  .qr-code {
+    margin-left: 25px;
+  }
+  .row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .small-font {
+    font-size: 0.75rem;
+  }
+  .highlight-on-hover:hover {
+    background-color: yellow;
+    cursor: default;
+  }
+  .highlight-on-hover:hover + .relative-pos > .err {
+    display: block;
+  }
+  pre, code.hljs {
+    overflow: auto;
+  }
+  .relative-pos {
+    position: relative;
+    width: 0.5rem;
+    height: 0.5rem;
+    z-index: 1;
+  }
+  .relative-pos:hover > .err {
+    display: block;
+  }
 </style>
 {{> abstract.hbs}}
 {{> test-statistics.hbs stats=stats}}

--- a/templates/body.hbs
+++ b/templates/body.hbs
@@ -4,11 +4,21 @@
     display: none;
   }
   .err {
-    position: relative;
+    position: absolute;
     z-index: 1;
-    width: 50rem;
-    right: calc(0% + 15rem);
+    white-space: nowrap;
+    left: -15rem;
     background: rgba(0, 0, 0, 0.0);
+  }
+  .err details {
+    background: white;
+    border: 1px solid darkgray;
+    text-align: left;
+    padding: .1em .5em;
+    box-shadow: 0 0 5px darkgray;
+  }
+  .err details summary {
+    color: indianred;
   }
   .no-space-around {
     margin: 0;

--- a/templates/body.hbs
+++ b/templates/body.hbs
@@ -3,21 +3,21 @@
   .hide {
     display: none;
   }
-  .err {
+  details.hide {
+    display: none;
+  }
+  details.err {
     position: absolute;
     z-index: 1;
     white-space: nowrap;
-    left: -15rem;
-    background: rgba(0, 0, 0, 0.0);
-  }
-  .err details {
     background: white;
     border: 1px solid darkgray;
     text-align: left;
     padding: .1em .5em;
     box-shadow: 0 0 5px darkgray;
+    min-width: 25em;
   }
-  .err details summary {
+  details.err summary {
     color: indianred;
   }
   .no-space-around {

--- a/templates/body.hbs
+++ b/templates/body.hbs
@@ -1,2 +1,30 @@
+<!-- these are not in <head> in order to override Respec injected styles -->
+<style>
+  .hide {
+    display: none;
+  }
+  .err {
+    position: relative;
+    z-index: 1;
+    width: 50rem;
+    right: calc(0% + 15rem);
+    background: rgba(0, 0, 0, 0.0);
+  }
+  .no-space-around {
+    margin: 0;
+    padding: 0;
+  }
+  pre {
+    width: 75%;
+    white-space: pre-line;
+    word-break: break-all;
+    margin: 0;
+    padding: 0;
+    background: white;
+  }
+  code > span.hljs-attr {
+    margin-left: 1rem;
+  }
+</style>
 {{> abstract.hbs}}
 {{> test-statistics.hbs stats=stats}}

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,10 +1,8 @@
 <div class="relative-pos">
   {{#if error}}
-  <div class="err hide">
-    <details>
-      <summary>{{error.message}}:</summary>
-      <pre>{{error.stack}}</pre>
-    </details>
-  </div>
+  <details class="err hide">
+    <summary>{{error.message}}:</summary>
+    <pre>{{error.stack}}</pre>
+  </details>
   {{/if}}
 </div>

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,7 +1,10 @@
 <div class="relative-pos">
   {{#if error}}
-  <span class="err hide no-space-around">
-    <pre>{{{formatError error}}}</pre>
-  </span>
+  <div class="err hide">
+    <details>
+      <summary>{{error.message}}:</summary>
+      <pre>{{error.stack}}</pre>
+    </details>
+  </div>
   {{/if}}
 </div>

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,31 +1,4 @@
 <div class="relative-pos">
-  <style>
-   .hide {
-     display: none;
-   }
-   .err {
-     position: relative;
-     z-index: 1;
-     width: 50rem;
-     right: calc(0% + 15rem);
-     background: rgba(0, 0, 0, 0.0);
-   }
-   .no-space-around {
-     margin: 0;
-     padding: 0;
-   }
-   pre {
-     width: 75%;
-     white-space: pre-line;
-     word-break: break-all;
-     margin: 0;
-     padding: 0;
-     background: white;
-   }
-   code > span.hljs-attr {
-     margin-left: 1rem;
-   }
-  </style>
   {{#if error}}
   <span class="err hide no-space-around">
     <pre>{{{formatError error}}}</pre>

--- a/templates/matrix.hbs
+++ b/templates/matrix.hbs
@@ -1,52 +1,5 @@
 <section class="informative" id="{{matrix.title}}">
   <h2>{{matrix.title}}</h2>
-  <style>
-    .no-wrap {
-      white-space: nowrap;
-    }
-    td.optional {
-      background-color: #b9b7b7;
-    }
-   .text-right {
-      text-align: right;
-    }
-   .text-left {
-      text-align: left;
-    }
-   .text-center, th.text-center {
-     text-align: center;
-   }
-   .qr-code {
-     margin-left: 25px;
-   }
-   .row {
-     display: flex;
-     justify-content: space-between;
-     align-items: center;
-   }
-   .small-font {
-     font-size: 0.75rem;
-   }
-   .highlight-on-hover:hover {
-     background-color: yellow;
-     cursor: default;
-   }
-   .highlight-on-hover:hover + .relative-pos > .err {
-     display: block;
-   }
-   pre, code.hljs {
-     overflow: auto;
-   }
-   .relative-pos {
-     position: relative;
-     width: 0.5rem;
-     height: 0.5rem;
-     z-index: 1;
-   }
-   .relative-pos:hover > .err {
-     display: block;
-   }
-  </style>
   <div class="row">
     <table class="simple">
       <thead>
@@ -60,7 +13,7 @@
         </th>
           {{#each matrix.columns}}
             <th class="no-wrap small-font text-center">{{this}}</th>
-          {{/each}} 
+          {{/each}}
         </thead>
       <tbody>
     {{#each matrix.rows}}


### PR DESCRIPTION
- Move error styles to body.hbs
- Move matrix styles into body.hbs.
- Use more focused error display style.

Before:
![image](https://github.com/user-attachments/assets/e55825c8-477b-4a05-a8e9-eea801436c94)

After:
![image](https://github.com/user-attachments/assets/9d31617a-9c61-4224-b484-e5fe4d31b5be)
...and with the `<details>` open...
![image](https://github.com/user-attachments/assets/042c306a-0af7-41b9-9ea1-4d9756d32959)

Still some minor CSS width issues on the content (inside `<details>`), but generally this feels like an improvement. Especially as I add more meaningful error messages to tests.