### PR TITLE
Add skip reason to test results in table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/mocha-w3c-interop-reporter ChangeLog
 
+## 1.8.0 -
+
+### Added
+- Skipped tests show either `skipMessage`, error, or `Test Skipped`.
+
 ## 1.7.0 - 2024-07-22
 
 ### Added

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -78,6 +78,12 @@ export function makeRows({tests, implemented, notImplemented}) {
     // check that all implementations have results
     for(const colName of implemented) {
       const result = cells.find(test => test?.cell?.columnId === colName);
+      if(result?.state === 'pending' && !result?.err) {
+        result.err = {
+          message: result?.cell?.skipMessage || 'Test skipped.'
+        };
+      }
+      console.log({result});
       // if an implementation doesn't have a result add a pending
       if(!result) {
         const columnIndex = columnIds.indexOf(colName);


### PR DESCRIPTION
```js
it('some test', function() {
  this.test.cell = {rowId: 'foo', columnId: 'bar', skipMessage: 'skipped for a reason'}
})
```
this was tested with ECDSA and it worked.