### PR TITLE
Add no-print css class so that elements can be discluded from printed reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/mocha-w3c-interop-reporter ChangeLog
 
+## 1.9.1 -
+
+### Fixed
+- Mouse Over Error Boxes do not appear in printed reports.
+
 ## 1.9.0 - 2024-09-30
 
 ### Added

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,4 +1,4 @@
-<div class="relative-pos">
+<div class="relative-pos no-print">
   {{#if error}}
   {{#if error.stack}}
   <details class="err hide">

--- a/templates/head.hbs
+++ b/templates/head.hbs
@@ -37,4 +37,9 @@
   outline: thin #c45e0a solid;
 }
 
+@media print {
+  .no-print, .no-print * {
+    display: none !important;
+  }
+}
     </style>


### PR DESCRIPTION
Features:
- Adds the ability to hide error pop ups from printed reports.
- The should help to ensure the report conforms to w3c report guidelines