### PR TITLE
Fix CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ This can be used to debug results with out having to rerun an entire test suite.
 npx interopReporter makeReport --suiteLog=./suite.log --output=./reports/manualReport.html
 ```
 
+The above reporter options can also be persisted in a JSON config to pass to the
+CLI in the `--config` parameter.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -38,7 +38,8 @@ yargs(hideBin(argv))
 async function makeReportHandler(commands) {
   const output = commands?.output;
   const config = commands?.config ?
-    (await getJson(commands.config)) : getConfig();
+    (getConfig({reporterOptions: await getJson(commands.config)})) :
+    getConfig();
   const suite = commands?.suiteLog ?
     (await getJson(commands.suiteLog)) : false;
   const html = await makeReport({

--- a/lib/files.js
+++ b/lib/files.js
@@ -78,7 +78,7 @@ const noCircular = (key, value) => {
   const circular = ['ctx', 'parent'];
   if(circular.includes(key)) {
     // replace circular refs with their id or null
-    return value.id || null;
+    return value?.id || null;
   }
   return value;
 };


### PR DESCRIPTION
The CLI is useful when you want to regenerate HTML output without rerunning the test suite.