### PR TITLE
Add respec.json to packaged files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "lib/*",
     "dist/*",
-    "templates/*"
+    "templates/*",
+    "respec.json"
   ],
   "scripts": {
     "rollup": "rollup -c rollup.config.js",


### PR DESCRIPTION
Without this patch, this line fails current if `respec` isn't a passed in parameter at runtime:
https://github.com/digitalbazaar/mocha-w3c-interop-reporter/blob/main/lib/config.js#L22